### PR TITLE
add ?= to other variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILDER?=docker # you may use podman if in Linux
-OPERATOR_NAME=cic-operator
-BUNDLE_DIR=manifests-435264820/cic-operator
-PUSH_REGISTRY=
+OPERATOR_NAME?=cic-operator
+BUNDLE_DIR?=manifests-435264820/cic-operator
+PUSH_REGISTRY?=quay.io
 # PUSH_REGISTRY=scan.connect.redhat.com #after testing uncomment this one
 PROJECT_ID=cic-operator
 FLAT?='false'


### PR DESCRIPTION
Might be easier to set environment variables and have the makefile pick those up rather than editing the makefile per operator? Reading through the docs, that's what I assumed was happening but then my Make target started working with a different bundle than I expected. The workflow I had was as follows, if it doesn't make sense let me know.

```bash
BUILDER=docker
OPERATOR_NAME=myoperator-certified
BUNDLE_DIR=manifests-123456789/myoperator-certified
PUSH_REGISTRY=my.push.registry
make migrate-bundle
```

The response I got was like the following:

```
$ make migrate-bundle 
./migrate.sh manifests-435264820/some-unrelated-operator
migrating manifests-435264820/some-unrelated-operator/*/
Error: stat /Users/me/Projects/2020-08-bundle-migration/bundle-migration/manifests-435264820/some-unrelated-operator/*: no such file or directory
```

The `some-unrelated-operator` and `manifests-435264820` were the hard-coded values.