### PR TITLE
adding verbosity to tag and push make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ build-bundle-images:
 tag-bundle-images:
 
 	for operator_tag in $$(${BUILDER} images | grep ${OPERATOR_NAME} | awk '{print $$2}'); \
-		do ${BUILDER} tag ${OPERATOR_NAME}:$$operator_tag ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag; \
+		do echo "tagging ${OPERATOR_NAME}:$$operator_tag ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag"; \
+		${BUILDER} tag ${OPERATOR_NAME}:$$operator_tag ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag; \
 	done;
 
 # Finally push to the official repo
@@ -55,5 +56,6 @@ tag-bundle-images:
 push-bundle-images:
 
 	for operator_tag in $$(${BUILDER} images | grep ${PUSH_REGISTRY}/${PROJECT_ID} | awk '{print $$2}'); \
-		do ${BUILDER} push ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag; \
+		do echo "pushing ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag"; \
+		${BUILDER} push ${PUSH_REGISTRY}/${PROJECT_ID}:$$operator_tag; \
 	done;


### PR DESCRIPTION
Adding some log lines to the tag and push outputs. Push has some output already, but the log lines might serve as an anchor (so you know when each version's push action takes place). Tag is fairly quiet from what I can see, so it would look like this with this change merged.

```
$ make tag-bundle-images 
for operator_tag in $(docker images | grep mongodb-enterprise | awk '{print $2}'); \
		do echo "tagging mongodb-enterprise:$operator_tag quay.io/mongodb-enterprise:$operator_tag"; \
		docker tag mongodb-enterprise:$operator_tag quay.io/mongodb-enterprise:$operator_tag; \
	done;
tagging mongodb-enterprise:1.6.0 quay.io/mongodb-enterprise:1.6.0
tagging mongodb-enterprise:1.5.5 quay.io/mongodb-enterprise:1.5.5
tagging mongodb-enterprise:1.5.4 quay.io/mongodb-enterprise:1.5.4
tagging mongodb-enterprise:1.5.3 quay.io/mongodb-enterprise:1.5.3
tagging mongodb-enterprise:1.5.2 quay.io/mongodb-enterprise:1.5.2
tagging mongodb-enterprise:1.5.1 quay.io/mongodb-enterprise:1.5.1
tagging mongodb-enterprise:1.4.5 quay.io/mongodb-enterprise:1.4.5
tagging mongodb-enterprise:1.4.4 quay.io/mongodb-enterprise:1.4.4
tagging mongodb-enterprise:1.4.3 quay.io/mongodb-enterprise:1.4.3
tagging mongodb-enterprise:1.4.2 quay.io/mongodb-enterprise:1.4.2
tagging mongodb-enterprise:1.4.1 quay.io/mongodb-enterprise:1.4.1
tagging mongodb-enterprise:1.4.0 quay.io/mongodb-enterprise:1.4.0
tagging mongodb-enterprise:1.3.1 quay.io/mongodb-enterprise:1.3.1
tagging mongodb-enterprise:1.3.0 quay.io/mongodb-enterprise:1.3.0
tagging mongodb-enterprise:1.2.4 quay.io/mongodb-enterprise:1.2.4
tagging mongodb-enterprise:1.2.3 quay.io/mongodb-enterprise:1.2.3
tagging mongodb-enterprise:1.2.2 quay.io/mongodb-enterprise:1.2.2
tagging mongodb-enterprise:1.2.1 quay.io/mongodb-enterprise:1.2.1
tagging mongodb-enterprise:1.1.0 quay.io/mongodb-enterprise:1.1.0
tagging mongodb-enterprise:0.9.0 quay.io/mongodb-enterprise:0.9.0
tagging mongodb-enterprise:0.3.2 quay.io/mongodb-enterprise:0.3.2
```